### PR TITLE
🐛 Fix: 修复图片链接返回undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,8 @@ hexo.extend.filter.register('after_post_render', (data) => {
         if (p2.startsWith(pre_url)) {
             let img_url = p2.replace(pre_url, proxy_url);
             return str.replace(p2, img_url)
+        } else {
+            return str;
         }
     });
 }, priority);


### PR DESCRIPTION
若图片链接不以配置文件指定的被替换域名开头时，依旧会出现undefined。
现已修复。